### PR TITLE
Protect VERBATIM block in DESTRUCTOR block.

### DIFF
--- a/mod/vecevent.mod
+++ b/mod/vecevent.mod
@@ -66,10 +66,12 @@ NET_RECEIVE (w) {
 
 DESTRUCTOR {
 VERBATIM
+#if !NRNBBCORE
 	void* vv = (void*)(_p_ptr);  
         if (vv) {
 		hoc_obj_unref(*vector_pobj(vv));
 	}
+#endif
 ENDVERBATIM
 }
 


### PR DESCRIPTION
Fixes compilation when translated with NMODL+OpenACC.

See also: https://github.com/neuronsimulator/nrn/pull/1296

cc: @iomaganaris @pramodk 