### PR TITLE
Fix initialisation of iarray when number of vecstim instances are 0

### DIFF
--- a/mod/vecevent.mod
+++ b/mod/vecevent.mod
@@ -126,7 +126,7 @@ static void bbcore_write(double* xarray, int* iarray, int* xoffset, int* ioffset
   if (_p_ptr) {
     dsize = vector_capacity(_p_ptr);
   }
-  if (xarray) {
+  if (iarray) {
     void* vec = _p_ptr;
     ia = iarray + *ioffset;
     xa = xarray + *xoffset;


### PR DESCRIPTION
If the number of VecStims are 0 then `iarray` should
be initialized to indicate the count. Otherwise
initialised values causes issue like
https://github.com/neuronsimulator/nrn/issues/1472